### PR TITLE
Add debug flag to Android payload for current live app

### DIFF
--- a/src/main/scala/com/gu/mobile/notifications/football/lib/GoalNotificationBuilder.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/GoalNotificationBuilder.scala
@@ -67,6 +67,7 @@ object AndroidPayloadBuilder {
   val HomeTeamScore = "HOME_TEAM_SCORE"
   val AwayTeamScore = "AWAY_TEAM_SCORE"
   val MatchId = "matchId"
+  val Debug = "debug"
 
   def apply(goal: Goal, matchDay: MatchDay): AndroidMessagePayload = {
     AndroidMessagePayload(Map(
@@ -79,7 +80,9 @@ object AndroidPayloadBuilder {
       ScorerName -> goal.scorerName,
       GoalMins -> goal.minute.toString,
       OtherTeamName -> (Set(matchDay.homeTeam, matchDay.awayTeam) - goal.scoringTeam).head.name,
-      MatchId -> matchDay.id
+      MatchId -> matchDay.id,
+      /** This flag exists for legacy reasons (the current PROD Android app will break if it's not here) */
+      Debug -> "false"
     ))
   }
 }


### PR DESCRIPTION
The current Android app expects this flag to exist (even though we're not using it in the future). If it does not it will crash, so it needs to be in the goal notifications. (It's still in the breaking news alerts.)
