### PR TITLE
Logging improvements

### DIFF
--- a/src/main/scala/com/gu/mobile/notifications/football/Streams.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/Streams.scala
@@ -29,8 +29,8 @@ trait MatchDayStream extends Logging {
       todaysMatchesFuture onFailure {
         case pae: PaClientErrorsException if pae.msg.contains("No data available") =>
           logger.info(s"No match data available for today [${LocalDate.now}]")
-        case error: Throwable =>
-          logger.error(s"Error getting today's matches from PA [${error.getMessage}]")
+        case e: Exception =>
+          logger.error(s"Error getting today's matches from PA [${e.getMessage}]", e)
       }
 
       Observable.from(todaysMatchesFuture).completeOnError

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/PaClient.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/PaClient.scala
@@ -10,7 +10,7 @@ trait DispatchHttp extends pa.Http with Logging {
   def GET(urlString: String): Future[Response] = {
     import ExecutionContext.Implicits.global
 
-    logger.debug("Http GET " + urlString)
+    logger.debug("Http GET " + urlString.replaceAll(GoalNotificationsConfig.paApiKey, "<api-key>"))
     dispatch.Http(url(urlString) OK as.Response(r => Response(r.getStatusCode, r.getResponseBody, r.getStatusText)))
   }
 }


### PR DESCRIPTION
* hide PA api key in logs
* "no data available" error from PA translated to info message

Fixes https://github.com/guardian/mobile-notifications-football/issues/22