### PR TITLE
cache http calls 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ libraryDependencies ++= {
     "io.spray" %% "spray-can" % sprayV,
     "io.spray" %% "spray-routing" % sprayV,
     "io.spray" %% "spray-json" % sprayV,
+    "io.spray" %% "spray-caching" % sprayV,
     "com.typesafe.akka" %% "akka-agent" % akkaV,
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,

--- a/src/main/scala/com/gu/mobile/notifications/football/GoalNotificationsPipeline.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/GoalNotificationsPipeline.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object GoalNotificationsPipeline extends GoalNotificationsPipeline {
   val MaxHistoryLength: Int = 100
   val retrySendNotifications: Int = 5
-  val UpdateInterval = 30.seconds
+  val UpdateInterval = 1.hour
 }
 
 trait GoalNotificationsPipeline extends Streams with SNSQueue with GoalNotificationLogger {

--- a/src/main/scala/com/gu/mobile/notifications/football/Streams.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/Streams.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 import com.gu.mobile.notifications.football.observables.MatchEventsObservable
 import pa.{PaClientErrorsException, MatchDay}
 import com.gu.mobile.notifications.football.lib.PaMatchDayClient
+import scala.concurrent.duration._
 
 trait MatchDayStream extends Logging {
   val UpdateInterval: FiniteDuration
@@ -23,7 +24,7 @@ trait MatchDayStream extends Logging {
   def getMatchDayStream: Observable[List[MatchDay]] = {
     // Use the subject below rather than subscribe to the stream directly - otherwise more calls are kicked off to PA
     // than are required
-    val stream = Observable.interval(UpdateInterval) flatMap { _ =>
+    val stream = Observable.timer(0.second, UpdateInterval) flatMap { _ =>
       val todaysMatchesFuture = PaMatchDayClient(PaFootballClient).today
 
       todaysMatchesFuture onFailure {

--- a/src/main/scala/com/gu/mobile/notifications/football/observables/MatchEventsObservable.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/observables/MatchEventsObservable.scala
@@ -16,7 +16,7 @@ object MatchEventsObservable extends MatchEventsObservableLogic with Logging {
 
   val pollingIntervalTolerance = 5.seconds
 
-  val pollingInterval = 15.seconds
+  val pollingInterval = 60.seconds
 }
 
 object MatchEventsObservableLogic {


### PR DESCRIPTION
I did not manage to fix the logic of that service. As discussed with @davidfurey this is a dirty but efficient way to block the higher than expected amount of calls we make to PA.

This is hopefully temporary and will stick around until we decommission that service for a lambda version.

I pushed the refresh time of the matches to 1hour, and the refresh time per match to 1 minute