### PR TITLE
Fix loop of death

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -137,7 +137,7 @@ Resources:
         KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: 20
-        WriteCapacityUnits: 10
+        WriteCapacityUnits: 20
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -169,7 +169,7 @@ Resources:
       Dimensions:
       - Name: TableName
         Value: !Ref dynamoTable
-      Threshold: 10
+      Threshold: 20
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]

--- a/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -89,7 +89,7 @@ object Lambda extends Logging {
       .map(_.flatMap(eventConsumer.receiveEvents))
       .flatMap(notificationSender.sendNotifications)
 
-    Await.ready(result, 35.seconds)
+    Await.ready(result, 50.seconds)
     "done"
   }
 

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/EventFilter.scala
@@ -1,7 +1,7 @@
 package com.gu.mobile.notifications.football.lib
 
 import com.gu.Logging
-import com.gu.mobile.notifications.football.lib.DynamoDistinctCheck.Distinct
+import com.gu.mobile.notifications.football.lib.DynamoDistinctCheck._
 import pa.MatchEvent
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,6 +19,9 @@ class CachedEventFilter(distinctCheck: DynamoDistinctCheck) extends EventFilter 
         case Distinct =>
           processedEvents = processedEvents + eventId
           Some(event)
+        case Duplicate =>
+          processedEvents = processedEvents + eventId
+          None
         case _ => None
       }
     } getOrElse {


### PR DESCRIPTION
Duplicate events weren't put in cache, which is a bad idea.

Putting the explanation here just in case:

If the lambda start off a fresh container, it suddenly has to deal with a lot of events (cold cache). This had the side effect of triggering throttle events by dynamoDB. This had the following behaviour:
 - Lambda didn't cache the duplicate events
 - DynamoDb throttle calls as there's a large amount of events to check for duplicate
 - The lambda times out and crashes
 - AWS immediately restarts the lambda making the throttling event worse
 - rinse and repeat

This won't prevent throttle events from happening, but it should eventually recover by continuing to fill the cache rather than starting from scratch every time.

This is now:
 - caching duplicate events
 - doubling the write capacity
 - extending the timeout closer to the hard 60s limit as it's currently configured in the lambda.

In case of a massive event flood I believe this should put us in a position where the lambda recovers automatically.