### PR TITLE
Fix timeout loop

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -67,7 +67,7 @@ Resources:
                 - dynamodb:PutItem
                 - dynamodb:UpdateItem
                 - dynamodb:Query
-              Resource: !Sub arn:aws:dynamodb:eu-west-1:201359054765:table/${Stack}-${App}-events-${Stage}
+              Resource: !Sub arn:aws:dynamodb:eu-west-1:201359054765:table/${Stack}-${App}-notifications-${Stage}
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -125,15 +125,15 @@ Resources:
           MetricName: "error"
           MetricValue: 1
 
-  dynamoTable:
+  DynamoTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Stack}-${App}-events-${Stage}
+      TableName: !Sub ${Stack}-${App}-notifications-${Stage}
       AttributeDefinitions:
-        - AttributeName: eventId
+        - AttributeName: notificationId
           AttributeType: S
       KeySchema:
-      - AttributeName: eventId
+      - AttributeName: notificationId
         KeyType: HASH
       ProvisionedThroughput:
         ReadCapacityUnits: 5
@@ -152,7 +152,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
       - Name: TableName
-        Value: !Ref dynamoTable
+        Value: !Ref DynamoTable
       Threshold: 10
       Period: 300
       EvaluationPeriods: 1
@@ -168,58 +168,8 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
       - Name: TableName
-        Value: !Ref dynamoTable
+        Value: !Ref DynamoTable
       Threshold: 10
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]
-
-  WriteCapacityScalableTarget:
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Properties:
-      MaxCapacity: 100
-      MinCapacity: 20
-      ResourceId: !Sub table/${dynamoTable}
-      RoleARN: !GetAtt ScalingRole.Arn
-      ScalableDimension: dynamodb:table:WriteCapacityUnits
-      ServiceNamespace: dynamodb
-
-  ScalingRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: [ application-autoscaling.amazonaws.com ]
-          Action: [ "sts:AssumeRole" ]
-      Path: /
-      Policies:
-      - PolicyName: root
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
-          - Effect: Allow
-            Action:
-              - dynamodb:DescribeTable
-              - dynamodb:UpdateTable
-              - cloudwatch:PutMetricAlarm
-              - cloudwatch:DescribeAlarms
-              - cloudwatch:GetMetricStatistics
-              - cloudwatch:SetAlarmState
-              - cloudwatch:DeleteAlarms
-            Resource: "*"
-
-  WriteScalingPolicy:
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: WriteAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ScalingTargetId: !Ref WriteCapacityScalableTarget
-      TargetTrackingScalingPolicyConfiguration:
-        TargetValue: 70.0
-        ScaleInCooldown: 300
-        ScaleOutCooldown: 30
-        PredefinedMetricSpecification:
-          PredefinedMetricType: DynamoDBWriteCapacityUtilization

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -83,7 +83,7 @@ Resources:
           App: !Ref App
       Description: Send Goal Alert notifications
       Handler: com.gu.mobile.notifications.football.Lambda::handler
-      MemorySize: 384
+      MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -136,13 +136,13 @@ Resources:
       - AttributeName: eventId
         KeyType: HASH
       ProvisionedThroughput:
-        ReadCapacityUnits: 20
+        ReadCapacityUnits: 5
         WriteCapacityUnits: 20
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
 
-  mobileNotificationsFootballConsumedReadThrottleEvents:
+  MobileNotificationsFootballConsumedReadThrottleEvents:
     Type: AWS::CloudWatch::Alarm
     Properties:
       Namespace: AWS/DynamoDB
@@ -153,12 +153,12 @@ Resources:
       Dimensions:
       - Name: TableName
         Value: !Ref dynamoTable
-      Threshold: 20
+      Threshold: 10
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]
 
-  mobileNotificationsFootballConsumedWriteThrottleEvents:
+  MobileNotificationsFootballConsumedWriteThrottleEvents:
     Type: AWS::CloudWatch::Alarm
     Properties:
       Namespace: AWS/DynamoDB
@@ -169,7 +169,57 @@ Resources:
       Dimensions:
       - Name: TableName
         Value: !Ref dynamoTable
-      Threshold: 20
+      Threshold: 10
       Period: 300
       EvaluationPeriods: 1
       AlarmActions: [ !Ref DynamoNotificationTopic ]
+
+  WriteCapacityScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 100
+      MinCapacity: 20
+      ResourceId: !Sub table/${dynamoTable}
+      RoleARN: !GetAtt ScalingRole.Arn
+      ScalableDimension: dynamodb:table:WriteCapacityUnits
+      ServiceNamespace: dynamodb
+
+  ScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ application-autoscaling.amazonaws.com ]
+          Action: [ "sts:AssumeRole" ]
+      Path: /
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:UpdateTable
+              - cloudwatch:PutMetricAlarm
+              - cloudwatch:DescribeAlarms
+              - cloudwatch:GetMetricStatistics
+              - cloudwatch:SetAlarmState
+              - cloudwatch:DeleteAlarms
+            Resource: "*"
+
+  WriteScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: WriteAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref WriteCapacityScalableTarget
+      TargetTrackingScalingPolicyConfiguration:
+        TargetValue: 70.0
+        ScaleInCooldown: 300
+        ScaleOutCooldown: 30
+        PredefinedMetricSpecification:
+          PredefinedMetricType: DynamoDBWriteCapacityUtilization

--- a/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -94,7 +94,7 @@ object Lambda extends Logging {
     val result = footballData.pollFootballData
       .flatMap(eventFilter.filterRawMatchDataList)
       .flatMap(articleSearcher.tryToMatchWithCapiArticle)
-      .map(_.flatMap(eventConsumer.receiveEvents))
+      .map(_.flatMap(eventConsumer.eventsToNotifications))
       .flatMap(notificationSender.sendNotifications)
 
     Try(Await.ready(result, 40.seconds)).recover {

--- a/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/Lambda.scala
@@ -22,7 +22,7 @@ object Lambda extends Logging {
 
   var cachedLambda: Boolean = false
 
-  def tableName = s"mobile-notifications-football-events-${configuration.stage}"
+  def tableName = s"mobile-notifications-football-notifications-${configuration.stage}"
 
   lazy val configuration: Configuration = {
     logger.debug("Creating configuration")
@@ -92,9 +92,9 @@ object Lambda extends Logging {
     logContainer()
 
     val result = footballData.pollFootballData
-      .flatMap(eventFilter.filterRawMatchDataList)
       .flatMap(articleSearcher.tryToMatchWithCapiArticle)
       .map(_.flatMap(eventConsumer.eventsToNotifications))
+      .flatMap(eventFilter.filterNotifications)
       .flatMap(notificationSender.sendNotifications)
 
     Try(Await.ready(result, 40.seconds)).recover {

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/ArticleSearcher.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/ArticleSearcher.scala
@@ -2,13 +2,13 @@ package com.gu.mobile.notifications.football.lib
 
 import com.gu.Logging
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.mobile.notifications.football.models.{FilteredMatchData, MatchDataWithArticle}
+import com.gu.mobile.notifications.football.models.{MatchDataWithArticle, RawMatchData}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ArticleSearcher(capiClient: GuardianContentClient) extends Logging {
 
-  def tryToMatchWithCapiArticle(matchData: List[FilteredMatchData])(implicit ec: ExecutionContext): Future[List[MatchDataWithArticle]] = {
+  def tryToMatchWithCapiArticle(matchData: List[RawMatchData])(implicit ec: ExecutionContext): Future[List[MatchDataWithArticle]] = {
     Future.traverse(matchData){ filteredMatchData =>
       val homeTeam = filteredMatchData.matchDay.homeTeam.id
       val awayTeam = filteredMatchData.matchDay.awayTeam.id

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/Batch.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/Batch.scala
@@ -1,0 +1,25 @@
+package com.gu.mobile.notifications.football.lib
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// this is a simple way to limit how we're using resources
+// without falling into using rate limiting or more complex thread pooling stuff
+object Batch {
+  def process[E, R](
+    elements: List[E],
+    batchSize: Int
+  )(processOne: E => Future[R])
+  (implicit ec: ExecutionContext): Future[List[R]] = {
+
+    def batchProcessing(agg: List[R], remainingBatches: List[List[E]]): Future[List[R]] = {
+      remainingBatches.headOption match {
+        case Some(batch) => Future.traverse(batch)(processOne)
+          .flatMap { result => batchProcessing(agg ++ result, remainingBatches.tail)}
+        case None => Future.successful(agg)
+      }
+    }
+
+    val batches = elements.grouped(batchSize).toList
+    batchProcessing(Nil, batches)
+  }
+}

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -13,7 +13,7 @@ class EventConsumer(
   matchStatusNotificationBuilder: MatchStatusNotificationBuilder
 ) extends Logging {
 
-  def receiveEvents(matchData: MatchDataWithArticle): List[NotificationPayload] = {
+  def eventsToNotifications(matchData: MatchDataWithArticle): List[NotificationPayload] = {
     matchData.filteredEvents.flatMap { event =>
       receiveEvent(matchData.matchDay, matchData.allEvents, event, matchData.articleId)
     }

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -41,9 +41,6 @@ class EventConsumer(
     val sentGoalAlert = condOpt(event) { case goal: Goal => goalNotificationBuilder.build(goal, matchDay, previousEvents) }
     val sentMatchStatus = Some(matchStatusNotificationBuilder.build(event, matchDay, previousEvents, articleId))
 
-    val notifications = List(sentGoalAlert, sentMatchStatus).flatten
-    logger.info(s"Prepared the following notifications for match ${matchDay.id}, event $event: $notifications")
-
-    notifications
+    List(sentGoalAlert, sentMatchStatus).flatten
   }
 }

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/EventConsumer.scala
@@ -14,7 +14,7 @@ class EventConsumer(
 ) extends Logging {
 
   def eventsToNotifications(matchData: MatchDataWithArticle): List[NotificationPayload] = {
-    matchData.filteredEvents.flatMap { event =>
+    matchData.allEvents.flatMap { event =>
       receiveEvent(matchData.matchDay, matchData.allEvents, event, matchData.articleId)
     }
   }

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/FootballData.scala
@@ -22,7 +22,7 @@ class FootballData(
 
     val matchesData = for {
       liveMatches <- matchIdsInProgress
-      md <- Future.traverse(liveMatches)(processMatch)
+      md <- Batch.process(liveMatches, 5)(processMatch)
     } yield md.flatten
 
     matchesData andThen {

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/NotificationSender.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/NotificationSender.scala
@@ -14,11 +14,12 @@ class NotificationSender(notificationClient: ApiClient) extends Logging {
   }
 
   def sendNotification(notification: NotificationPayload)(implicit ec: ExecutionContext): Future[Unit] = {
+    val notificationString = notification.toString.replaceAll("\n", "")
     notificationClient.send(notification).map {
-      case Right(_) => logger.info(s"Match status for $notification successfully sent")
-      case Left(error) => logger.error(s"Error sending match status for $notification - ${error.description}")
+      case Right(_) => logger.info(s"Match status for $notificationString successfully sent")
+      case Left(error) => logger.error(s"Error sending match status for $notificationString - ${error.description}")
     }.recover {
-      case NonFatal(exception) => logger.error(s"Error sending match status for $notification ${exception.getMessage}", exception)
+      case NonFatal(exception) => logger.error(s"Error sending match status for $notificationString ${exception.getMessage}", exception)
     }
   }
 }

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
@@ -9,6 +9,8 @@ import org.joda.time.DateTime
 
 trait OkHttp extends pa.Http with Logging {
 
+  implicit val ec: ExecutionContext
+
   val httpClient = new OkHttpClient
 
   def apiKey: String
@@ -17,13 +19,13 @@ trait OkHttp extends pa.Http with Logging {
     logger.info("Http GET " + urlString.replaceAll(apiKey, "<api-key>"))
     val httpRequest = new Request.Builder().url(urlString).build()
     val httpResponse = httpClient.newCall(httpRequest).execute()
-    Future.successful(Response(httpResponse.code(), httpResponse.body().string, httpResponse.message()))
+    Future(Response(httpResponse.code(), httpResponse.body().string, httpResponse.message()))
   }
 }
 
 class PaFootballClient(override val apiKey: String, apiBase: String) extends PaClient with OkHttp {
 
-  import ExecutionContext.Implicits.global
+  override implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
 
   override lazy val base = apiBase
 

--- a/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/lib/PaFootballClient.scala
@@ -1,10 +1,12 @@
 package com.gu.mobile.notifications.football.lib
 
+import java.io.IOException
+
 import com.gu.Logging
 import pa._
 
-import scala.concurrent.{ExecutionContext, Future}
-import okhttp3.{OkHttpClient, Request}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import okhttp3.{Call, Callback, OkHttpClient, Request}
 import org.joda.time.DateTime
 
 trait OkHttp extends pa.Http with Logging {
@@ -16,10 +18,19 @@ trait OkHttp extends pa.Http with Logging {
   def apiKey: String
 
   def GET(urlString: String): Future[Response] = {
+
+    val promise = Promise[Response]
+
     logger.info("Http GET " + urlString.replaceAll(apiKey, "<api-key>"))
     val httpRequest = new Request.Builder().url(urlString).build()
-    val httpResponse = httpClient.newCall(httpRequest).execute()
-    Future(Response(httpResponse.code(), httpResponse.body().string, httpResponse.message()))
+    httpClient.newCall(httpRequest).enqueue(new Callback {
+      override def onFailure(call: Call, e: IOException): Unit = promise.failure(e)
+      override def onResponse(call: Call, response: okhttp3.Response): Unit = {
+        promise.success(Response(response.code(), response.body().string, response.message()))
+      }
+    })
+
+    promise.future
   }
 }
 

--- a/src/main/scala/com/gu/mobile/notifications/football/models/MatchData.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/models/MatchData.scala
@@ -6,22 +6,9 @@ case class RawMatchData(
   matchDay: MatchDay,
   allEvents: List[MatchEvent]
 ) {
-  def withFilteredEvents(filteredEvents: List[MatchEvent]): FilteredMatchData = FilteredMatchData(
-    matchDay = matchDay,
-    allEvents = allEvents,
-    filteredEvents = filteredEvents
-  )
-}
-
-case class FilteredMatchData(
-  matchDay: MatchDay,
-  allEvents: List[MatchEvent],
-  filteredEvents: List[MatchEvent]
-) {
   def withArticle(articleId: Option[String]): MatchDataWithArticle = MatchDataWithArticle(
     matchDay = matchDay,
     allEvents = allEvents,
-    filteredEvents = filteredEvents,
     articleId = articleId
   )
 }
@@ -29,6 +16,5 @@ case class FilteredMatchData(
 case class MatchDataWithArticle(
   matchDay: MatchDay,
   allEvents: List[MatchEvent],
-  filteredEvents: List[MatchEvent],
   articleId: Option[String]
 )

--- a/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -253,6 +253,6 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     def matchDay: MatchDay = Parser.parseMatchDay(loadFile("20170811.xml")).head
 
     def events: List[MatchEvent] = new SyntheticMatchEventGenerator().generate(rawEvents, "4011135", matchDay)
-    def matchData = MatchDataWithArticle(matchDay, events, events, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
+    def matchData = MatchDataWithArticle(matchDay, events, Some("football/live/2017/aug/11/arsenal-v-leicester-city-premier-league-live"))
   }
 }

--- a/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
+++ b/src/test/scala/com/gu/mobile/notifications/football/lib/EventConsumerSpec.scala
@@ -20,7 +20,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     "generate a kick-off notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO")
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = "Kick-off!",
@@ -57,7 +57,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     "generate half-time notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "HT")
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = "Half-time",
@@ -96,7 +96,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
       override def rawEvents: List[MatchEvent] = super.rawEvents.takeWhile(!_.id.contains("23572566"))
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "SHS")
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = "Second-half start",
@@ -133,7 +133,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     "generate full time notification" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "FT", result = true)
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = "Full-Time",
@@ -170,7 +170,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     "generate goal notifications from FootballMatchStatusPayload" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO", result = true)
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = FootballMatchStatusPayload(
         title = "Goal!",
@@ -207,7 +207,7 @@ class EventConsumerSpec(implicit ev: ExecutionEnv) extends Specification with Mo
     "generate goal notifications from GoalAlertPayload" in new MatchEventsContext {
       override def matchDay: MatchDay = super.matchDay.copy(matchStatus = "KO", result = true)
 
-      val result: List[NotificationPayload] = eventConsumer.receiveEvents(matchData)
+      val result: List[NotificationPayload] = eventConsumer.eventsToNotifications(matchData)
 
       val expectedNotification = GoalAlertPayload(
         title = "The Guardian",


### PR DESCRIPTION
The lambda have failed in timeout when being overwhelmed by more than 20 matches at the same time.

20 matches isn't a rare occurrence so I decided to fix it. This was due to a couple of effects:

- Connections to PA were serialised, that takes quite a while for 20 something games
- More importantly, the dynamodb was storing one line for every event at the PA level, That's convenient for debugging, but PA publishes a LOT of events, leading us to be rate limited by dynamo.

I tried autoscaling the dynamodb table, but the nature of the data means that we get huge spikes that are hard to scale in time (dynamo db manage to scale about 20 minutes after the spike)

I solve this by:
- connecting to PA in parallel (with a limit of 5 connections at the same time)
- De-duplicating at the notification level rather than the event level

That means I had to create a new dynamodb table for notifications to replace the event one.