### PR TITLE
Venue can be empty, in which case it should be transformed to None

### DIFF
--- a/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
+++ b/src/main/scala/com/gu/mobile/notifications/football/notificationbuilders/MatchStatusNotificationBuilder.scala
@@ -44,7 +44,7 @@ class MatchStatusNotificationBuilder(mapiHost: String) {
       homeTeamId = matchInfo.homeTeam.id,
       matchId = matchInfo.id,
       competitionName = matchInfo.competition.map(_.name),
-      venue = matchInfo.venue.map(_.name),
+      venue = matchInfo.venue.map(_.name).filter(_.nonEmpty),
       matchInfoUri = new URI(s"$mapiHost/sport/football/matches/${matchInfo.id}"),
       articleUri = articleId.map(id => new URI(s"$mapiHost/items/$id")),
       importance = importance(triggeringEvent),


### PR DESCRIPTION
We had a venue provided as an empty string and this caused persistence problems to dynamodb (which doesn't like String attribute values to be empty).